### PR TITLE
Rename repository from cfg-generics -> generics

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -78,7 +78,7 @@ git clone https://github.com/osism/release /release
 
 # run preparations
 git clone https://github.com/osism/ansible-playbooks /playbooks
-git clone https://github.com/osism/cfg-generics /generics
+git clone https://github.com/osism/generics /generics
 
 if [ "$VERSION" != "latest" ]; then
   ( cd /release || exit; git fetch --all --force; git checkout "ceph-ansible-$VERSION" )


### PR DESCRIPTION
## Summary
- `osism/cfg-generics` was renamed to `osism/generics`. Update the `git clone` call in the Containerfile to use the new URL directly.
- GitHub's rename alias keeps the old URL working, so this is not a break fix; it brings the build in line with the rest of the ecosystem.

## Test plan
- [ ] Image build succeeds; `/generics` is populated from `osism/generics`