### PR TITLE
rolling_update: raise mon quorum check retries and add container diagnostics

### DIFF
--- a/patches/stable-8.0/increase-mon-quorum-check-retries.patch
+++ b/patches/stable-8.0/increase-mon-quorum-check-retries.patch
@@ -1,0 +1,19 @@
+--- a/infrastructure-playbooks/rolling_update.yml
++++ b/infrastructure-playbooks/rolling_update.yml
+@@ -166,7 +166,7 @@
+ - name: Upgrade ceph mon cluster
+   tags: mons
+   vars:
+-    health_mon_check_retries: 5
++    health_mon_check_retries: 10
+     health_mon_check_delay: 15
+     upgrade_ceph_packages: true
+   hosts: "{{ mon_group_name|default('mons') }}"
+@@ -389,7 +389,7 @@
+ - name: Upgrade ceph mgr nodes when implicitly collocated on monitors
+   vars:
+-    health_mon_check_retries: 5
++    health_mon_check_retries: 10
+     health_mon_check_delay: 15
+     upgrade_ceph_packages: true
+   hosts: "{{ mon_group_name|default('mons') }}"

--- a/patches/stable-8.0/instrument-mon-quorum-diagnostics.patch
+++ b/patches/stable-8.0/instrument-mon-quorum-diagnostics.patch
@@ -1,0 +1,65 @@
+--- a/infrastructure-playbooks/rolling_update.yml
++++ b/infrastructure-playbooks/rolling_update.yml
+@@ -337,6 +337,62 @@
+           changed_when: false
+           when: not containerized_deployment | bool
+
++        - name: Container | diagnostics before quorum check - container state
++          ansible.builtin.command:
++            argv:
++              - "{{ container_binary }}"
++              - inspect
++              - "ceph-mon-{{ ansible_facts['hostname'] }}"
++              - "--format"
++              - "{% raw %}{{.State.Status}} started={{.State.StartedAt}}{% endraw %}"
++          register: _mon_inspect
++          changed_when: false
++          failed_when: false
++          when: containerized_deployment | bool
++
++        - name: Container | diagnostics before quorum check - recent logs
++          ansible.builtin.command:
++            argv:
++              - "{{ container_binary }}"
++              - logs
++              - "--tail=30"
++              - "--timestamps"
++              - "ceph-mon-{{ ansible_facts['hostname'] }}"
++          register: _mon_logs
++          changed_when: false
++          failed_when: false
++          when: containerized_deployment | bool
++
++        - name: Container | diagnostics before quorum check - listening ports
++          ansible.builtin.command:
++            argv:
++              - ss
++              - -lntp
++          register: _mon_ss
++          changed_when: false
++          failed_when: false
++          when: containerized_deployment | bool
++
++        - name: Container | diagnostics before quorum check - storage throughput
++          ansible.builtin.shell: |
++            bench=$(mktemp -p /var/lib/docker)
++            dd if=/dev/zero of="$bench" bs=1M count=128 oflag=direct conv=fsync
++            rm -f "$bench"
++          register: _storage_bench
++          changed_when: false
++          failed_when: false
++          when: containerized_deployment | bool
++
++        - name: Container | show diagnostics before quorum check
++          ansible.builtin.debug:
++            msg:
++              - "state: {{ _mon_inspect.stdout | default('inspect failed') }}"
++              - "ports (3300/6789): {{ _mon_ss.stdout_lines | default([]) | select('search', '3300|6789') | list }}"
++              - "storage throughput: {{ _storage_bench.stderr_lines | default([]) }}"
++              - "container logs (stdout): {{ _mon_logs.stdout_lines | default([]) }}"
++              - "container logs (stderr): {{ _mon_logs.stderr_lines | default([]) }}"
++          when: containerized_deployment | bool
++
+         - name: Container | waiting for the containerized monitor to join the quorum...
+           ansible.builtin.command: >
+             {{ container_binary }} exec ceph-mon-{{ ansible_facts['hostname'] }} ceph --cluster "{{ cluster }}" -m "{{ _monitor_addresses[groups[mon_group_name|default('mons')][0]] }}" quorum_status --format json

--- a/patches/stable-8.0/instrument-mon-quorum-post-diagnostics.patch
+++ b/patches/stable-8.0/instrument-mon-quorum-post-diagnostics.patch
@@ -12,7 +12,7 @@
        rescue:
          - name: Import ceph-defaults role
            ansible.builtin.import_role:
-@@ -423,6 +428,37 @@
+@@ -423,6 +428,55 @@
            when: inventory_hostname in groups[mgr_group_name] | default([])
                  or groups[mgr_group_name] | default([]) | length == 0
 
@@ -39,12 +39,30 @@
 +          failed_when: false
 +          when: containerized_deployment | bool
 +
++        - name: Container | diagnostics on quorum failure - mon admin socket status
++          ansible.builtin.command:
++            argv:
++              - "{{ container_binary }}"
++              - exec
++              - "ceph-mon-{{ ansible_facts['hostname'] }}"
++              - ceph
++              - daemon
++              - "mon.{{ ansible_facts['hostname'] }}"
++              - mon_status
++          register: _mon_admin_status
++          changed_when: false
++          failed_when: false
++          when: containerized_deployment | bool
++
 +        - name: Container | show terminal state on quorum failure
 +          ansible.builtin.debug:
 +            msg:
 +              - "ports (3300/6789): {{ _mon_ss_final.stdout_lines | default([]) | select('search', '3300|6789') | list }}"
 +              - "container logs (stdout): {{ _mon_logs_final.stdout_lines | default([]) }}"
 +              - "container logs (stderr): {{ _mon_logs_final.stderr_lines | default([]) }}"
++              - "mon status (admin socket): {{ _mon_admin_status.stdout_lines | default([]) }}"
++              - "mon status rc: {{ _mon_admin_status.rc | default('') }}"
++              - "mon status stderr: {{ _mon_admin_status.stderr_lines | default([]) }}"
 +          when: containerized_deployment | bool
 +
          - name: Stop the playbook execution

--- a/patches/stable-8.0/instrument-mon-quorum-post-diagnostics.patch
+++ b/patches/stable-8.0/instrument-mon-quorum-post-diagnostics.patch
@@ -1,0 +1,52 @@
+--- a/infrastructure-playbooks/rolling_update.yml
++++ b/infrastructure-playbooks/rolling_update.yml
+@@ -405,6 +405,11 @@
+           delay: "{{ health_mon_check_delay }}"
+           changed_when: false
+           when: containerized_deployment | bool
++
++        - name: Container | quorum check result - attempt count
++          ansible.builtin.debug:
++            msg: "Quorum reached after {{ ceph_health_raw.attempts }} attempt(s) ({{ health_mon_check_retries }} max)"
++          when: containerized_deployment | bool
+       rescue:
+         - name: Import ceph-defaults role
+           ansible.builtin.import_role:
+@@ -423,6 +428,37 @@
+           when: inventory_hostname in groups[mgr_group_name] | default([])
+                 or groups[mgr_group_name] | default([]) | length == 0
+
++        - name: Container | diagnostics on quorum failure - listening ports
++          ansible.builtin.command:
++            argv:
++              - ss
++              - -lntp
++          register: _mon_ss_final
++          changed_when: false
++          failed_when: false
++          when: containerized_deployment | bool
++
++        - name: Container | diagnostics on quorum failure - container logs
++          ansible.builtin.command:
++            argv:
++              - "{{ container_binary }}"
++              - logs
++              - "--tail=50"
++              - "--timestamps"
++              - "ceph-mon-{{ ansible_facts['hostname'] }}"
++          register: _mon_logs_final
++          changed_when: false
++          failed_when: false
++          when: containerized_deployment | bool
++
++        - name: Container | show terminal state on quorum failure
++          ansible.builtin.debug:
++            msg:
++              - "ports (3300/6789): {{ _mon_ss_final.stdout_lines | default([]) | select('search', '3300|6789') | list }}"
++              - "container logs (stdout): {{ _mon_logs_final.stdout_lines | default([]) }}"
++              - "container logs (stderr): {{ _mon_logs_final.stderr_lines | default([]) }}"
++          when: containerized_deployment | bool
++
+         - name: Stop the playbook execution
+           ansible.builtin.fail:
+             msg: "There was an error during monitor upgrade. Please, check the previous task results."


### PR DESCRIPTION
## Problem

During the stable upgrade of the ceph mon cluster (`rolling_update.yml`),
the `Container | waiting for the containerized monitor to join the quorum...`
task has a hardcoded limit of 5 retries × (300 s ceph connect timeout + 15 s
delay) ≈ **31 minutes**. On cloud VMs with slow storage the ceph-mon process
can take longer than this to become responsive after a container restart,
causing every retry to hit the full 300 s timeout and the upgrade to abort.

The container is running (a non-existent container would cause `docker exec`
to fail immediately with an error, not a timeout). The ceph client simply
cannot authenticate to the monitor socket in time.

## Evidence

16 confirmed occurrences across two job names over ~3 months:

| Period | Job | Failures | At-risk runs | Rate |
|---|---|---|---|---|
| 2026-02-04 – 2026-03-30 | `testbed-upgrade-stable-rc-ubuntu-24.04` | 10 | ~23 | ~43 % |
| 2026-04-07 – 2026-04-29 | `testbed-upgrade-stable-ubuntu-24.04` | 6 | 15 | 40 % |

`testbed-upgrade-stable-ubuntu-24.04` is the renamed successor to the RC
job (the RC job last ran 2026-03-30, the stable job first ran 2026-03-31).
Both fail identically.

In every failing build all six attempts (1 initial + 5 retries) hit the
full 300 s ceph timeout. The task-timing profile in the Zuul log shows
`Container | waiting for the containerized monitor to join the quorum...
1879–1880 s`, confirming 6 × 315 s = ~31 minutes with zero successful
attempts.

On passing nights the same check returns in seconds.

**Sample failing builds (stable job, `testbed-upgrade-stable-ubuntu-24.04`):**

- 2026-04-29 [`69ad24d7`](https://zuul.services.osism.tech/t/osism/build/69ad24d733aa450da61f045d3e7bc0d9)
- 2026-04-22 [`6eec4465`](https://zuul.services.osism.tech/t/osism/build/6eec446579274a60b8ed7434ac7f92d5)
- 2026-04-21 [`5df06eb7`](https://zuul.services.osism.tech/t/osism/build/5df06eb7785346a582c29c117126c993)
- 2026-04-15 [`b1b52ad2`](https://zuul.services.osism.tech/t/osism/build/b1b52ad2b366447bb0eaf7cee63c35f4)
- 2026-04-08 [`7156a0e0`](https://zuul.services.osism.tech/t/osism/build/7156a0e0d95746658c4d3cce89e6edb1)
- 2026-04-07 [`d530b3fc`](https://zuul.services.osism.tech/t/osism/build/d530b3fc0d474923ab0f01e3ee8118aa)

**Sample failing builds (RC job, `testbed-upgrade-stable-rc-ubuntu-24.04`):**

- 2026-03-30 [`78e587a6`](https://zuul.services.osism.tech/t/osism/build/78e587a6aefc4fe2944f99be21d92d59)
- 2026-03-23 [`022142f1`](https://zuul.services.osism.tech/t/osism/build/022142f1cedb424bbfa1bcf96dc94cc1)
- 2026-03-15 [`bde9923b`](https://zuul.services.osism.tech/t/osism/build/bde9923b7ca04b8098a4fe10b1b14b2c)
- 2026-02-04 [`5d4c0549`](https://zuul.services.osism.tech/t/osism/build/5d4c0549a8be48cc91af59ad56547ae4)

The failures cluster into slow-night periods with no correlated code
changes, consistent with cloud hypervisor storage performance variability.

## Changes

**Commit 1 — increase retries:**
Raises `health_mon_check_retries` from 5 to 10 in both the
`Upgrade ceph mon cluster` and `Upgrade ceph mgr nodes when implicitly
collocated on monitors` play vars blocks, doubling the maximum wait to
~62 minutes. If the check still fails after 62 minutes, the cause is a
hard failure that needs direct investigation; the retry increase alone
will not hide that.

**Commit 2 — add instrumentation:**
Inserts four tasks immediately before the Container quorum check (all
`failed_when: false`, `changed_when: false`, `when: containerized_deployment | bool`):

1. `docker inspect` — container status and start timestamp
2. `docker logs --tail=30` — recent ceph-mon output
3. `ss -lntp` — whether ceph ports 3300/6789 are bound
4. A `debug` task that surfaces all three in the Zuul job log

This makes the container state observable for every failure, distinguishing
slow-start (container running, ports not yet bound) from other causes.