### PR TITLE
Containerfile: sort patches for deterministic apply order

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -137,7 +137,7 @@ rm /mitogen.tar.gz
 # prepare project repository
 PROJECT_VERSION=$(grep "ceph_ansible_version:" /release/latest/ceph-$CEPH_VERSION.yml | awk -F': ' '{ print $2 }')
 git clone -b $PROJECT_VERSION https://github.com/ceph/ceph-ansible /repository
-for patchfile in $(find /patches/$PROJECT_VERSION -name "*.patch"); do
+for patchfile in $(find /patches/$PROJECT_VERSION -name "*.patch" | LC_ALL=C sort); do
   echo $patchfile;
   ( cd /repository && patch --forward --batch -p1 --dry-run ) < $patchfile || exit 1;
   ( cd /repository && patch --forward --batch -p1 ) < $patchfile;


### PR DESCRIPTION
## Summary

- `find` does not guarantee result ordering, making patch application non-deterministic inside container builds
- In `stable-8.0`, six patches touch `infrastructure-playbooks/rolling_update.yml`; `instrument-mon-quorum-diagnostics.patch` has a context-line dependency on `fix-group-names-in-rolling-update-play.patch` — if applied in the wrong order, `patch` fails to match context and aborts the build
- Fix: pipe `find` through `LC_ALL=C sort` so patches are always applied in reproducible, byte-order-sorted filename order, which matches the required dependency order for all existing patch sets

Spotted via osism/container-image-kolla-ansible#901, which applies the same fix to the kolla-ansible image.

## Test plan

- [ ] Build container image for each supported ceph-ansible version (`stable-7.0`, `stable-8.0`, `stable-9.0`) and verify all patches apply cleanly
- [ ] Confirm `stable-8.0` applies `fix-group-names-in-rolling-update-play.patch` before `instrument-mon-quorum-diagnostics.patch`