### PR TITLE
build: drop redundant Python library pins

### DIFF
--- a/files/src/requirements.txt
+++ b/files/src/requirements.txt
@@ -1,6 +1,4 @@
 Jinja2==3.1.6
 PyYAML==6.0.3
 netaddr==1.3.0
-pottery==3.0.1
-setuptools==80.10.2
 yq==3.4.3

--- a/files/src/templates/requirements.txt.j2
+++ b/files/src/templates/requirements.txt.j2
@@ -14,7 +14,6 @@ ansible-core{{ ansible_core_version }}
 ansible-core=={{ ansible_core_version }}
 {% endif %}
 {% endif %}
-asn1crypto==1.5.1
 cryptography==46.0.5
 notario==0.0.16
 osism=={{ osism_projects['osism'] }}

--- a/files/src/templates/requirements.txt.j2
+++ b/files/src/templates/requirements.txt.j2
@@ -14,11 +14,8 @@ ansible-core{{ ansible_core_version }}
 ansible-core=={{ ansible_core_version }}
 {% endif %}
 {% endif %}
-ara=={{ osism_projects['ara'] }}
 asn1crypto==1.5.1
 cryptography==46.0.5
-docker==7.1.0
-idna==3.11
 notario==0.0.16
 osism=={{ osism_projects['osism'] }}
 paramiko==4.0.0


### PR DESCRIPTION
Remove pins from `files/src/templates/requirements.txt.j2` and
`files/src/requirements.txt` that are already covered by
`python-osism`'s `install_requires`. When a container installs
`osism==X.Y.Z`, all of python-osism's pinned libraries arrive as
hard transitive constraints; re-pinning them here is redundant and
creates Renovate race conditions.

## Changes

**Commit 1 — drop redundant pins:**
- Template: `ara`, `docker`, `idna`
- Static: `pottery`, `setuptools` (also version-drifted: 80.10.2 here vs 82.0.1 in python-osism)

**Commit 2 — drop `asn1crypto`:**
Image inspection confirmed no runtime consumer: no pip package declares
`Requires-Dist: asn1crypto`; `jc` uses a vendored internal copy
(`jc.parsers.asn1crypto`), not the system package. osism-kubernetes
already runs without the system package.

## Test plan

- [ ] `container-image-ceph-ansible-build-quincy` passes
- [ ] `container-image-ceph-ansible-build-reef` passes
- [ ] `container-image-ceph-ansible-build-squid` passes

Related: [osism-ansible #747](https://github.com/osism/container-image-osism-ansible/pull/747), [kolla-ansible #906](https://github.com/osism/container-image-kolla-ansible/pull/906), [osism-kubernetes #296](https://github.com/osism/osism-kubernetes/pull/296), [osism/issues#1366](https://github.com/osism/issues/issues/1366)