### PR TITLE
openstack_config: set require-min-compat-client on OSD map

### DIFF
--- a/files/playbooks/tasks/openstack_config.yml
+++ b/files/playbooks/tasks/openstack_config.yml
@@ -67,3 +67,45 @@
   when:
     - cephx | bool
     - openstack_config | bool
+
+- name: Assert ceph_require_min_compat_client is a known release
+  ansible.builtin.assert:
+    that:
+      - ceph_require_min_compat_client in ceph_min_compat_client_order
+    fail_msg: >-
+      ceph_require_min_compat_client '{{ ceph_require_min_compat_client }}' is not in
+      ceph_min_compat_client_order. Add the release to the map or set
+      ceph_require_min_compat_client to '' to skip.
+  when: ceph_require_min_compat_client | default('', true) | string | length > 0
+
+- name: Gather facts for the first Ceph monitor
+  ansible.builtin.setup:
+    gather_subset:
+      - min
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+  delegate_facts: true
+  when: ceph_require_min_compat_client | default('', true) | string | length > 0
+
+- name: Get Ceph OSD map
+  ansible.builtin.command: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_facts']['hostname'] }} ceph osd dump --format json"
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+  register: _ceph_osd_dump
+  changed_when: false
+  when: ceph_require_min_compat_client | default('', true) | string | length > 0
+
+- name: Evaluate whether require-min-compat-client needs raising
+  ansible.builtin.set_fact:
+    _ceph_set_min_compat_client: >-
+      {{ _current in ceph_min_compat_client_order
+         and (ceph_min_compat_client_order[_current] | int)
+             < (ceph_min_compat_client_order[ceph_require_min_compat_client] | int) }}
+  vars:
+    _current: "{{ (_ceph_osd_dump.stdout | default('{}') | from_json).require_min_compat_client | default('luminous') }}"
+  when: ceph_require_min_compat_client | default('', true) | string | length > 0
+
+- name: Set Ceph minimum compatible client
+  ansible.builtin.command: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_facts']['hostname'] }} ceph osd set-require-min-compat-client {{ ceph_require_min_compat_client }}"
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+  when: >-
+    ceph_require_min_compat_client | default('', true) | string | length > 0
+    and (_ceph_set_min_compat_client | default(false) | bool)


### PR DESCRIPTION
## Summary

- Appends five tasks to `files/playbooks/tasks/openstack_config.yml` (after the cephx key block) that conditionally raise the Ceph OSD map `require-min-compat-client` to the release named by `ceph_require_min_compat_client`
- Default value (`mimic`) is provided by the companion PR in `osism/defaults` (#284)

**Why:** With the default Ceph compat level (luminous), Nova creates RBD clone v1 clones that hold a protection lock on their parent snapshot. When Glance tries to delete the base image, `glance_store`'s RBD driver calls `unprotect_snap()`, which raises `ImageBusy` under clone v1 — surfaced as HTTP 409. Setting the minimum compat client to `mimic` enables RBD clone v2 cluster-wide: protection locks are no longer used, `unprotect_snap()` succeeds, and the deletion proceeds through `trash_move()` (introduced in glance_store 4.6.0). This fixes the two `tempest.api.image.v2.test_images_dependency.ImageDependencyTests`.

**Implementation details:**
- Assert task validates `ceph_require_min_compat_client` is a known release in `ceph_min_compat_client_order` (defined in `osism/defaults`)
- Gathers minimal facts for the first monitor host (needed to build the `ceph-mon-<hostname>` container name)
- Reads current OSD dump as JSON, evaluates ordering against the map — only raises the compat level, never lowers it
- All tasks guarded by `ceph_require_min_compat_client | default('', true) | string | length > 0`; set to `''` to skip entirely

**Side effects** (documented in `osism/defaults` variable comment):
- Ceph clients older than mimic (Ubuntu 18.04 era) are rejected cluster-wide — hard gate
- Glance image deletion with active RBD clones moves images to Ceph trash; space not reclaimed until all clones (Nova ephemeral disks) are gone
- Effectively one-way on a live cluster once clone v2 objects exist

**Insertion point:** `openstack_config.yml` runs in the `ceph-pools.yml` lifecycle step — after the cluster is up and configured, before Glance and Nova are deployed. This is the correct pre-OpenStack window.

## Test plan

- [ ] Bedbox end-to-end run with both this PR and `osism/defaults` #284: `ImageDependencyTests.test_image_volume_server_snapshot_dependency` and `test_nova_image_snapshot_dependency` pass
- [ ] Verify idempotency: re-running `ceph-pools.yml` on a cluster already at `mimic` produces no change
- [ ] Once confirmed in CI, revert the `exclude.lst` workaround from testbed PR #2885

Companion PR: osism/defaults#284

🤖 Generated with [Claude Code](https://claude.com/claude-code)