### PR TITLE
ansible: drop obsolete osism-fqcn noqa on blocks

### DIFF
--- a/files/playbooks/ceph-configure-lvm-volumes.yml
+++ b/files/playbooks/ceph-configure-lvm-volumes.yml
@@ -19,7 +19,7 @@
       delegate_to: "{{ groups['manager'][0] }}"
 
     - name: Ceph configure LVM
-      block:  # noqa: osism-fqcn
+      block:
         - name: Get initial list of available block devices
           ansible.builtin.set_fact:
             block_devices: "{{ hostvars[inventory_hostname].ansible_devices }}"

--- a/files/playbooks/ceph-create-lvm-devices.yml
+++ b/files/playbooks/ceph-create-lvm-devices.yml
@@ -18,7 +18,7 @@
       delegate_to: "{{ groups['manager'][0] }}"
 
     - name: Ceph create LVM devices
-      block:  # noqa: osism-fqcn
+      block:
         - name: Get initial list of available block devices
           ansible.builtin.set_fact:
             block_devices: "{{ hostvars[inventory_hostname].ansible_devices }}"


### PR DESCRIPTION
Remove the obsolete `# noqa: osism-fqcn` annotations from two playbooks.

The custom `osism-fqcn` ansible-lint rule previously emitted spurious
violations on `block`/`rescue`/`always` constructs. osism/container-images#902
fixed the rule and the updated `ansible-lint` image is published, so these
two annotations (both on `block:` lines, false-positives) are no longer
needed.

This is part of the cleanup sweep tracked in osism/issues#1368.

Note: syncing the vendored copy of the rule at
`.ansible-lint-rules/osism_fqcn.py` is intentionally left as a separate
follow-up item and is not touched in this PR.

Related-Bug: #1368