### PR TITLE
Drop vendored ansible-lint rules

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -15,8 +15,6 @@ exclude_paths:
   - files/playbooks/squid/ceph-purge-storage-node.yml
   - files/playbooks/tasks/openstack_config.yml
 use_default_rules: true
-rulesdir:
-  - ./.ansible-lint-rules/
 mock_roles:
   - ceph-client
   - ceph-config


### PR DESCRIPTION
Part of the osism/issues#1368 cleanup: retire the hand-vendored copies of the
`osism-fqcn` / `osism-attribute-order` ansible-lint rules in favour of the
canonical rules baked into the `registry.osism.tech/osism/ansible-lint` container.

This repo already lints via that container in CI, and the container entrypoint
force-overrides `rulesdir` to its baked-in canonical rules — so the local
`.ansible-lint-rules/` copy was already dead (it was in fact untracked here).
This removes the now-dangling `rulesdir` entry from `.ansible-lint`; no other
keys change.

Verified: the container still reports `0 failure(s)` after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
