### PR TITLE
[Squid]: Use ceph_key_info to get key

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -14,6 +14,7 @@ exclude_paths:
   - files/playbooks/squid/ceph-purge-cluster.yml
   - files/playbooks/squid/ceph-purge-storage-node.yml
   - files/playbooks/tasks/openstack_config.yml
+  - files/playbooks/tasks/openstack_config_pre_squid.yml
 use_default_rules: true
 mock_roles:
   - ceph-client

--- a/files/playbooks/quincy/ceph-pools.yml
+++ b/files/playbooks/quincy/ceph-pools.yml
@@ -14,6 +14,6 @@
   tasks:
     - name: Include tasks from the ceph-osd role
       ansible.builtin.include_tasks:
-        file: tasks/openstack_config.yml
+        file: tasks/openstack_config_pre_squid.yml
       when:
         - inventory_hostname == groups[osd_group_name] | last

--- a/files/playbooks/reef/ceph-pools.yml
+++ b/files/playbooks/reef/ceph-pools.yml
@@ -14,6 +14,6 @@
   tasks:
     - name: Include tasks from the ceph-osd role
       ansible.builtin.include_tasks:
-        file: tasks/openstack_config.yml
+        file: tasks/openstack_config_pre_squid.yml
       when:
         - inventory_hostname == groups[osd_group_name] | last

--- a/files/playbooks/tasks/openstack_config_pre_squid.yml
+++ b/files/playbooks/tasks/openstack_config_pre_squid.yml
@@ -39,7 +39,7 @@
       no_log: "{{ no_log_on_ceph_key_tasks }}"
 
     - name: get keys from monitors
-      ceph_key_info:
+      ceph_key:
         name: "{{ item.name }}"
         cluster: "{{ cluster }}"
         output_format: plain


### PR DESCRIPTION
The `squid` version off ceph-ansible introduced a `ceph_key_info` module and removed `state: info` from module `ceph_key` ([1]).

[1]
https://github.com/ceph/ceph-ansible/commit/a1f65bbd35ef4ef78c868d444ccdd32282db4457