### PR TITLE
build: drop redundant paramiko and PyMySQL pins

### DIFF
--- a/files/src/templates/requirements.txt.j2
+++ b/files/src/templates/requirements.txt.j2
@@ -17,6 +17,4 @@ ansible-core=={{ ansible_core_version }}
 cryptography==46.0.7
 notario==0.0.16
 osism=={{ osism_projects['osism'] }}
-paramiko==4.0.0
-PyMySQL==1.1.3
 requests==2.34.2


### PR DESCRIPTION
Drop the `paramiko` and `PyMySQL` pins from
`files/src/templates/requirements.txt.j2`. Both are in python-osism's
`install_requires` at the same versions, so they arrive as transitive
constraints when the container installs `osism`. No change to the
installed package set.

These two were deferred in the first round of pin removals pending
assessment of the open major/minor Renovate bumps. That deferral is
now obsolete — without this change, builds in this repo will start
failing on a schedule we don't control:

## The impending failure

python-osism has merged the PyMySQL 1.2.0 bump
(osism/python-osism#2295). Builds still pass today because the image
installs the *released* `osism==0.20260502.0` from PyPI (version taken
from `release/latest/base.yml`), whose `install_requires` still pins
`PyMySQL==1.1.3` — matching the pin in the template here.

The failure triggers when two pending events complete:

1. The next python-osism release is published. Tagging is a manual
   maintainer action that can happen any time (the last release was
   2026-05-02); everything downstream of the tag is automated: a
   GitHub workflow publishes to PyPI, carrying `PyMySQL==1.2.0` in
   `install_requires`.
2. Renovate's bump of `osism_projects.osism` merges in osism/release.
   Nothing stops it there: that repo's check pipeline runs linters
   only and builds no images.

From that moment every image build in this repo fails — the rendered
requirements contain both `osism==<new>` (requiring `PyMySQL==1.2.0`)
and `PyMySQL==1.1.3`, an unsatisfiable combination that uv rejects.
The first failures appear in the nightly periodic builds and in check
runs of unrelated open PRs; no CI run on the PR that introduces the
conflict would catch it.

## Runtime note on PyMySQL 1.2.0

Independent of this PR, the next osism release upgrades the containers
to PyMySQL 1.2.0, which changes runtime behavior: connections now
attempt TLS by default when the server supports it (affects
community.mysql tasks against MariaDB), `Connection.ping()` no longer
reconnects by default, and the error classes on the Cursor class were
removed. This PR neither adopts nor blocks that upgrade — it only
removes the pin that would otherwise turn it into a build failure. If
1.2.0 misbehaves at runtime, the fix or revert belongs in python-osism,
where the bump was merged.

## Note on paramiko 5

paramiko stays at 4.0.0: python-osism still pins it there, and its
paramiko 5 bump (osism/python-osism#2326) is unmerged. The assessment
of that major release moves there, where it belongs. For reference,
paramiko 5 is a crypto-policy release (removes SHA-1 `ssh-rsa`
signatures, SHA-1 key exchange, and GSSAPI; RSA keys keep working via
rsa-sha2); the APIs python-osism uses are unaffected. The practical
risk is legacy SSH endpoints (old switches/BMCs) that only speak
SHA-1-era algorithms — worth verifying before that PR merges.

## Obsoletes (can be closed)

- #685
- #688

## Sibling PRs

- osism/container-image-osism-ansible#751
- osism/container-image-kolla-ansible#913

## Related

- osism/python-osism#2295
- osism/python-osism#2326
- osism/issues#1366

## Test plan

- [ ] `container-image-ceph-ansible-build-quincy` passes
- [ ] `container-image-ceph-ansible-build-reef` passes
- [ ] `container-image-ceph-ansible-build-squid` passes