### PR TITLE
fix: probe live monmap for mon quorum

### DIFF
--- a/patches/stable-8.0/use-live-monmap-for-quorum-check.patch
+++ b/patches/stable-8.0/use-live-monmap-for-quorum-check.patch
@@ -1,0 +1,112 @@
+--- a/infrastructure-playbooks/rolling_update.yml
++++ b/infrastructure-playbooks/rolling_update.yml
+@@ -325,8 +325,52 @@
+           delegate_to: "{{ groups[mon_group_name][0] }}"
+           delegate_facts: true
+
++        - name: Non container | select a stable mon to read the monmap from
++          ansible.builtin.set_fact:
++            _ceph_quorum_read_host: "{{ ((groups[mon_group_name | default('mons')] | difference([inventory_hostname])) + [groups[mon_group_name | default('mons')][0]]) | first }}"
++          when: not containerized_deployment | bool
++
++        - name: Non container | read mon monmap from the stable peer
++          ansible.builtin.command: >
++            ceph --cluster "{{ cluster }}"
++            daemon mon.{{ hostvars[_ceph_quorum_read_host]['ansible_facts']['hostname'] }} mon_status
++          register: _monmap_read
++          delegate_to: "{{ _ceph_quorum_read_host }}"
++          changed_when: false
++          failed_when: false
++          ignore_unreachable: true
++          when: not containerized_deployment | bool
++
++        - name: Non container | initialize quorum probe address to the configured value
++          ansible.builtin.set_fact:
++            _mon0_probe_addr: "{{ _monitor_addresses[groups[mon_group_name | default('mons')][0]] }}"
++          when: not containerized_deployment | bool
++
++        - name: Non container | derive quorum probe address from the live monmap
++          when: not containerized_deployment | bool
++          block:
++            - name: Non container | set quorum probe address from monmap
++              ansible.builtin.set_fact:
++                _mon0_probe_addr: >-
++                  {{ (_monmap_read.stdout | from_json).monmap.mons
++                     | selectattr('name', 'equalto', hostvars[groups[mon_group_name | default('mons')][0]]['ansible_facts']['hostname'])
++                     | map(attribute='public_addr')
++                     | map('regex_replace', ':[0-9]+/[0-9]+$', '')
++                     | reject('equalto', '')
++                     | first }}
++              when: _monmap_read.rc | default(1) == 0
++          rescue:
++            - name: Non container | keep configured quorum probe address
++              ansible.builtin.debug:
++                msg: "monmap read/parse failed; using fallback {{ _mon0_probe_addr }}"
++
++        - name: Non container | show the quorum probe address
++          ansible.builtin.debug:
++            msg: "mon quorum probe: -m {{ _mon0_probe_addr }} (monmap read from {{ _ceph_quorum_read_host }})"
++          when: not containerized_deployment | bool
++
+         - name: Non container | waiting for the monitor to join the quorum...
+-          ansible.builtin.command: ceph --cluster "{{ cluster }}" -m "{{ _monitor_addresses[groups[mon_group_name|default('mons')][0]] }}" quorum_status --format json
++          ansible.builtin.command: ceph --cluster "{{ cluster }}" -m "{{ _mon0_probe_addr }}" quorum_status --format json
+           register: ceph_health_raw
+           until:
+             - ceph_health_raw.rc == 0
+@@ -393,9 +437,54 @@
+               - "container logs (stderr): {{ _mon_logs.stderr_lines | default([]) }}"
+           when: containerized_deployment | bool
+
++        - name: Container | select a stable mon to read the monmap from
++          ansible.builtin.set_fact:
++            _ceph_quorum_read_host: "{{ ((groups[mon_group_name | default('mons')] | difference([inventory_hostname])) + [groups[mon_group_name | default('mons')][0]]) | first }}"
++          when: containerized_deployment | bool
++
++        - name: Container | read mon monmap from the stable peer
++          ansible.builtin.command: >
++            {{ container_binary }} exec ceph-mon-{{ hostvars[_ceph_quorum_read_host]['ansible_facts']['hostname'] }}
++            ceph --cluster "{{ cluster }}"
++            daemon mon.{{ hostvars[_ceph_quorum_read_host]['ansible_facts']['hostname'] }} mon_status
++          register: _monmap_read
++          delegate_to: "{{ _ceph_quorum_read_host }}"
++          changed_when: false
++          failed_when: false
++          ignore_unreachable: true
++          when: containerized_deployment | bool
++
++        - name: Container | initialize quorum probe address to the configured value
++          ansible.builtin.set_fact:
++            _mon0_probe_addr: "{{ _monitor_addresses[groups[mon_group_name | default('mons')][0]] }}"
++          when: containerized_deployment | bool
++
++        - name: Container | derive quorum probe address from the live monmap
++          when: containerized_deployment | bool
++          block:
++            - name: Container | set quorum probe address from monmap
++              ansible.builtin.set_fact:
++                _mon0_probe_addr: >-
++                  {{ (_monmap_read.stdout | from_json).monmap.mons
++                     | selectattr('name', 'equalto', hostvars[groups[mon_group_name | default('mons')][0]]['ansible_facts']['hostname'])
++                     | map(attribute='public_addr')
++                     | map('regex_replace', ':[0-9]+/[0-9]+$', '')
++                     | reject('equalto', '')
++                     | first }}
++              when: _monmap_read.rc | default(1) == 0
++          rescue:
++            - name: Container | keep configured quorum probe address
++              ansible.builtin.debug:
++                msg: "monmap read/parse failed; using fallback {{ _mon0_probe_addr }}"
++
++        - name: Container | show the quorum probe address
++          ansible.builtin.debug:
++            msg: "mon quorum probe: -m {{ _mon0_probe_addr }} (monmap read from {{ _ceph_quorum_read_host }})"
++          when: containerized_deployment | bool
++
+         - name: Container | waiting for the containerized monitor to join the quorum...
+           ansible.builtin.command: >
+-            {{ container_binary }} exec ceph-mon-{{ ansible_facts['hostname'] }} ceph --cluster "{{ cluster }}" -m "{{ _monitor_addresses[groups[mon_group_name|default('mons')][0]] }}" quorum_status --format json
++            {{ container_binary }} exec ceph-mon-{{ ansible_facts['hostname'] }} ceph --cluster "{{ cluster }}" -m "{{ _mon0_probe_addr }}" quorum_status --format json
+           register: ceph_health_raw
+           until:
+             - ceph_health_raw.rc == 0

--- a/patches/stable-9.0/increase-mon-quorum-check-retries.patch
+++ b/patches/stable-9.0/increase-mon-quorum-check-retries.patch
@@ -1,0 +1,20 @@
+--- a/infrastructure-playbooks/rolling_update.yml
++++ b/infrastructure-playbooks/rolling_update.yml
+@@ -138,7 +138,7 @@
+ - name: Upgrade ceph mon cluster
+   tags: mons
+   vars:
+-    health_mon_check_retries: 5
++    health_mon_check_retries: 10
+     health_mon_check_delay: 15
+     upgrade_ceph_packages: true
+   hosts: "{{ mon_group_name|default('mons') }}"
+@@ -360,7 +360,7 @@
+ 
+ - name: Upgrade ceph mgr nodes when implicitly collocated on monitors
+   vars:
+-    health_mon_check_retries: 5
++    health_mon_check_retries: 10
+     health_mon_check_delay: 15
+     upgrade_ceph_packages: true
+   hosts: "{{ mon_group_name|default('mons') }}"

--- a/patches/stable-9.0/instrument-mon-quorum-diagnostics.patch
+++ b/patches/stable-9.0/instrument-mon-quorum-diagnostics.patch
@@ -1,0 +1,65 @@
+--- a/infrastructure-playbooks/rolling_update.yml
++++ b/infrastructure-playbooks/rolling_update.yml
+@@ -309,6 +309,62 @@
+           changed_when: false
+           when: not containerized_deployment | bool
+ 
++        - name: Container | diagnostics before quorum check - container state
++          ansible.builtin.command:
++            argv:
++              - "{{ container_binary }}"
++              - inspect
++              - "ceph-mon-{{ ansible_facts['hostname'] }}"
++              - "--format"
++              - "{% raw %}{{.State.Status}} started={{.State.StartedAt}}{% endraw %}"
++          register: _mon_inspect
++          changed_when: false
++          failed_when: false
++          when: containerized_deployment | bool
++
++        - name: Container | diagnostics before quorum check - recent logs
++          ansible.builtin.command:
++            argv:
++              - "{{ container_binary }}"
++              - logs
++              - "--tail=30"
++              - "--timestamps"
++              - "ceph-mon-{{ ansible_facts['hostname'] }}"
++          register: _mon_logs
++          changed_when: false
++          failed_when: false
++          when: containerized_deployment | bool
++
++        - name: Container | diagnostics before quorum check - listening ports
++          ansible.builtin.command:
++            argv:
++              - ss
++              - -lntp
++          register: _mon_ss
++          changed_when: false
++          failed_when: false
++          when: containerized_deployment | bool
++
++        - name: Container | diagnostics before quorum check - storage throughput
++          ansible.builtin.shell: |
++            bench=$(mktemp -p /var/lib/docker)
++            dd if=/dev/zero of="$bench" bs=1M count=128 oflag=direct conv=fsync
++            rm -f "$bench"
++          register: _storage_bench
++          changed_when: false
++          failed_when: false
++          when: containerized_deployment | bool
++
++        - name: Container | show diagnostics before quorum check
++          ansible.builtin.debug:
++            msg:
++              - "state: {{ _mon_inspect.stdout | default('inspect failed') }}"
++              - "ports (3300/6789): {{ _mon_ss.stdout_lines | default([]) | select('search', '3300|6789') | list }}"
++              - "storage throughput: {{ _storage_bench.stderr_lines | default([]) }}"
++              - "container logs (stdout): {{ _mon_logs.stdout_lines | default([]) }}"
++              - "container logs (stderr): {{ _mon_logs.stderr_lines | default([]) }}"
++          when: containerized_deployment | bool
++
+         - name: Container | waiting for the containerized monitor to join the quorum...
+           ansible.builtin.command: >
+             {{ container_binary }} exec ceph-mon-{{ ansible_facts['hostname'] }} ceph --cluster "{{ cluster }}" -m "{{ _monitor_addresses[groups[mon_group_name|default('mons')][0]] }}" quorum_status --format json

--- a/patches/stable-9.0/instrument-mon-quorum-post-diagnostics.patch
+++ b/patches/stable-9.0/instrument-mon-quorum-post-diagnostics.patch
@@ -1,0 +1,70 @@
+--- a/infrastructure-playbooks/rolling_update.yml
++++ b/infrastructure-playbooks/rolling_update.yml
+@@ -377,6 +377,11 @@
+           delay: "{{ health_mon_check_delay }}"
+           changed_when: false
+           when: containerized_deployment | bool
++
++        - name: Container | quorum check result - attempt count
++          ansible.builtin.debug:
++            msg: "Quorum reached after {{ ceph_health_raw.attempts }} attempt(s) ({{ health_mon_check_retries }} max)"
++          when: containerized_deployment | bool
+       rescue:
+         - name: Import ceph-defaults role
+           ansible.builtin.import_role:
+@@ -395,6 +400,55 @@
+           when: inventory_hostname in groups[mgr_group_name] | default([])
+                 or groups[mgr_group_name] | default([]) | length == 0
+ 
++        - name: Container | diagnostics on quorum failure - listening ports
++          ansible.builtin.command:
++            argv:
++              - ss
++              - -lntp
++          register: _mon_ss_final
++          changed_when: false
++          failed_when: false
++          when: containerized_deployment | bool
++
++        - name: Container | diagnostics on quorum failure - container logs
++          ansible.builtin.command:
++            argv:
++              - "{{ container_binary }}"
++              - logs
++              - "--tail=50"
++              - "--timestamps"
++              - "ceph-mon-{{ ansible_facts['hostname'] }}"
++          register: _mon_logs_final
++          changed_when: false
++          failed_when: false
++          when: containerized_deployment | bool
++
++        - name: Container | diagnostics on quorum failure - mon admin socket status
++          ansible.builtin.command:
++            argv:
++              - "{{ container_binary }}"
++              - exec
++              - "ceph-mon-{{ ansible_facts['hostname'] }}"
++              - ceph
++              - daemon
++              - "mon.{{ ansible_facts['hostname'] }}"
++              - mon_status
++          register: _mon_admin_status
++          changed_when: false
++          failed_when: false
++          when: containerized_deployment | bool
++
++        - name: Container | show terminal state on quorum failure
++          ansible.builtin.debug:
++            msg:
++              - "ports (3300/6789): {{ _mon_ss_final.stdout_lines | default([]) | select('search', '3300|6789') | list }}"
++              - "container logs (stdout): {{ _mon_logs_final.stdout_lines | default([]) }}"
++              - "container logs (stderr): {{ _mon_logs_final.stderr_lines | default([]) }}"
++              - "mon status (admin socket): {{ _mon_admin_status.stdout_lines | default([]) }}"
++              - "mon status rc: {{ _mon_admin_status.rc | default('') }}"
++              - "mon status stderr: {{ _mon_admin_status.stderr_lines | default([]) }}"
++          when: containerized_deployment | bool
++
+         - name: Stop the playbook execution
+           ansible.builtin.fail:
+             msg: "There was an error during monitor upgrade. Please, check the previous task results."

--- a/patches/stable-9.0/use-live-monmap-for-quorum-check.patch
+++ b/patches/stable-9.0/use-live-monmap-for-quorum-check.patch
@@ -1,0 +1,112 @@
+--- a/infrastructure-playbooks/rolling_update.yml
++++ b/infrastructure-playbooks/rolling_update.yml
+@@ -297,8 +297,52 @@
+           delegate_to: "{{ groups[mon_group_name][0] }}"
+           delegate_facts: true
+ 
++        - name: Non container | select a stable mon to read the monmap from
++          ansible.builtin.set_fact:
++            _ceph_quorum_read_host: "{{ ((groups[mon_group_name | default('mons')] | difference([inventory_hostname])) + [groups[mon_group_name | default('mons')][0]]) | first }}"
++          when: not containerized_deployment | bool
++
++        - name: Non container | read mon monmap from the stable peer
++          ansible.builtin.command: >
++            ceph --cluster "{{ cluster }}"
++            daemon mon.{{ hostvars[_ceph_quorum_read_host]['ansible_facts']['hostname'] }} mon_status
++          register: _monmap_read
++          delegate_to: "{{ _ceph_quorum_read_host }}"
++          changed_when: false
++          failed_when: false
++          ignore_unreachable: true
++          when: not containerized_deployment | bool
++
++        - name: Non container | initialize quorum probe address to the configured value
++          ansible.builtin.set_fact:
++            _mon0_probe_addr: "{{ _monitor_addresses[groups[mon_group_name | default('mons')][0]] }}"
++          when: not containerized_deployment | bool
++
++        - name: Non container | derive quorum probe address from the live monmap
++          when: not containerized_deployment | bool
++          block:
++            - name: Non container | set quorum probe address from monmap
++              ansible.builtin.set_fact:
++                _mon0_probe_addr: >-
++                  {{ (_monmap_read.stdout | from_json).monmap.mons
++                     | selectattr('name', 'equalto', hostvars[groups[mon_group_name | default('mons')][0]]['ansible_facts']['hostname'])
++                     | map(attribute='public_addr')
++                     | map('regex_replace', ':[0-9]+/[0-9]+$', '')
++                     | reject('equalto', '')
++                     | first }}
++              when: _monmap_read.rc | default(1) == 0
++          rescue:
++            - name: Non container | keep configured quorum probe address
++              ansible.builtin.debug:
++                msg: "monmap read/parse failed; using fallback {{ _mon0_probe_addr }}"
++
++        - name: Non container | show the quorum probe address
++          ansible.builtin.debug:
++            msg: "mon quorum probe: -m {{ _mon0_probe_addr }} (monmap read from {{ _ceph_quorum_read_host }})"
++          when: not containerized_deployment | bool
++
+         - name: Non container | waiting for the monitor to join the quorum...
+-          ansible.builtin.command: ceph --cluster "{{ cluster }}" -m "{{ _monitor_addresses[groups[mon_group_name|default('mons')][0]] }}" quorum_status --format json
++          ansible.builtin.command: ceph --cluster "{{ cluster }}" -m "{{ _mon0_probe_addr }}" quorum_status --format json
+           register: ceph_health_raw
+           until:
+             - ceph_health_raw.rc == 0
+@@ -365,9 +409,54 @@
+               - "container logs (stderr): {{ _mon_logs.stderr_lines | default([]) }}"
+           when: containerized_deployment | bool
+ 
++        - name: Container | select a stable mon to read the monmap from
++          ansible.builtin.set_fact:
++            _ceph_quorum_read_host: "{{ ((groups[mon_group_name | default('mons')] | difference([inventory_hostname])) + [groups[mon_group_name | default('mons')][0]]) | first }}"
++          when: containerized_deployment | bool
++
++        - name: Container | read mon monmap from the stable peer
++          ansible.builtin.command: >
++            {{ container_binary }} exec ceph-mon-{{ hostvars[_ceph_quorum_read_host]['ansible_facts']['hostname'] }}
++            ceph --cluster "{{ cluster }}"
++            daemon mon.{{ hostvars[_ceph_quorum_read_host]['ansible_facts']['hostname'] }} mon_status
++          register: _monmap_read
++          delegate_to: "{{ _ceph_quorum_read_host }}"
++          changed_when: false
++          failed_when: false
++          ignore_unreachable: true
++          when: containerized_deployment | bool
++
++        - name: Container | initialize quorum probe address to the configured value
++          ansible.builtin.set_fact:
++            _mon0_probe_addr: "{{ _monitor_addresses[groups[mon_group_name | default('mons')][0]] }}"
++          when: containerized_deployment | bool
++
++        - name: Container | derive quorum probe address from the live monmap
++          when: containerized_deployment | bool
++          block:
++            - name: Container | set quorum probe address from monmap
++              ansible.builtin.set_fact:
++                _mon0_probe_addr: >-
++                  {{ (_monmap_read.stdout | from_json).monmap.mons
++                     | selectattr('name', 'equalto', hostvars[groups[mon_group_name | default('mons')][0]]['ansible_facts']['hostname'])
++                     | map(attribute='public_addr')
++                     | map('regex_replace', ':[0-9]+/[0-9]+$', '')
++                     | reject('equalto', '')
++                     | first }}
++              when: _monmap_read.rc | default(1) == 0
++          rescue:
++            - name: Container | keep configured quorum probe address
++              ansible.builtin.debug:
++                msg: "monmap read/parse failed; using fallback {{ _mon0_probe_addr }}"
++
++        - name: Container | show the quorum probe address
++          ansible.builtin.debug:
++            msg: "mon quorum probe: -m {{ _mon0_probe_addr }} (monmap read from {{ _ceph_quorum_read_host }})"
++          when: containerized_deployment | bool
++
+         - name: Container | waiting for the containerized monitor to join the quorum...
+           ansible.builtin.command: >
+-            {{ container_binary }} exec ceph-mon-{{ ansible_facts['hostname'] }} ceph --cluster "{{ cluster }}" -m "{{ _monitor_addresses[groups[mon_group_name|default('mons')][0]] }}" quorum_status --format json
++            {{ container_binary }} exec ceph-mon-{{ ansible_facts['hostname'] }} ceph --cluster "{{ cluster }}" -m "{{ _mon0_probe_addr }}" quorum_status --format json
+           register: ceph_health_raw
+           until:
+             - ceph_health_raw.rc == 0


### PR DESCRIPTION
## Problem

The rolling-update mon quorum check (`... waiting for the ... monitor to join the quorum...`) fails intermittently (rc=2) on `testbed-upgrade-stable-ubuntu-24.04`, the only CI job that upgrades a live Ceph mon. The dominant cause is an **address-selection lottery**, not slow storage.

ceph-ansible's `roles/ceph-facts/tasks/set_monitor_address.yml` derives each mon's address as `all_ipv4_addresses | ips_in_ranges(public_network) | first`. When a host has more than one IP inside `public_network` (the testbed node has its fixed primary plus keepalived/kube-vip VIPs), `| first` is order-unstable. The address is computed at **deploy** (and baked into the monmap) and **recomputed** at **upgrade** time. When the two disagree — deploy bound `.8`, upgrade picks `.10` — the check runs `ceph -m .10 quorum_status` against an address where no mon listens and times out on every retry, despite a healthy cluster.

The vulnerable probe is **branch-independent**: `stable-9.0` (squid) carries the identical `-m "{{ _monitor_addresses[groups[mon_group_name|default('mons')][0]] }}"` code, so a real squid upgrade with multiple in-range IPs can hit the same timeout.

## Fix

Fix the **check**, not the address selection. Before each probe:

- Read the live monmap from a **stable peer** mon's admin socket — the first mon not being upgraded this iteration, so it is always up (`delegate_to` + `ignore_unreachable`). The admin socket is auth-free and network-free, so it can't be fooled by the address problem being fixed.
- Select node-0's entry by name and use its scalar `public_addr` for `-m`.
- On **any** failure — unreachable peer, non-zero rc, unparseable output, no matching entry, or empty address — fall back to the previously computed address, so behaviour never regresses.

This is **production-safe by construction**: it never changes a mon's address, so no monmap migration is needed (works on `.8`, `.10`, anything). Both the Container and Non-container probes are fixed.

## Scope: reef **and** squid

`stable-8.0` (reef) already carried the rest of the quorum-check hardening stack (retry-count bump + pre/post diagnostics) from a previous PR, so for reef this PR adds only `use-live-monmap-for-quorum-check.patch`.

`stable-9.0` (squid) carried **none** of that hardening, so this PR ports the **full stack** to squid so it matches reef:

- `increase-mon-quorum-check-retries.patch` — `health_mon_check_retries` 5 → 10 in the mon and collocated-mgr upgrade plays.
- `instrument-mon-quorum-diagnostics.patch` — emit container state, recent logs, listening ports, and storage throughput before each probe.
- `instrument-mon-quorum-post-diagnostics.patch` — report the attempt count on success; dump ports, logs, and the mon admin-socket status on terminal failure.
- `use-live-monmap-for-quorum-check.patch` — the live-monmap probe described above.

The squid patches make **content-identical** changes to the reef ones (verified line-by-line); only hunk offsets and surrounding context differ, since the squid patches stack on `fix-group-names-in-rolling-update-play.patch` which rewrites `groups['mons']` → `groups[mon_group_name|default('mons')]`.

No CI job currently upgrades a live squid mon, so the squid patches are latent hardening for real-world squid upgrades and future CI coverage.

## Testing

- All `patches/stable-8.0/*.patch` **and** `patches/stable-9.0/*.patch` apply cleanly (no fuzz) in `LC_ALL=C` sort order against fresh `stable-8.0` / `stable-9.0` clones; the resulting `rolling_update.yml` parses in both.
- The address-resolution + fallback pipeline was verified cluster-free against a monmap captured from a live reef cluster plus the failure cases (missing entry, malformed/empty JSON, empty `public_addr`, unreachable read) — all route correctly.
- Real signal after merge + image rebuild: the new debug line prints the chosen probe address; the periodic `testbed-upgrade-stable-ubuntu-24.04` job should stop exhibiting the Variant A timeout.

## Related

- osism/container-image-ceph-ansible#681

🤖 Generated with [Claude Code](https://claude.com/claude-code)
