### PR TITLE
Remove dead ceph_volume mock_modules entry

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -38,8 +38,6 @@ mock_roles:
   - ceph-rgw
   - ceph-validate
   - ensure-docker
-mock_modules:
-  - ceph_volume
 skip_list:
   - fqcn-builtins
   - key-order[task] # disabled because we use our own rule


### PR DESCRIPTION
`ceph_volume` is mocked in `.ansible-lint`, but every reference to it lives in playbooks already in `exclude_paths` (the ceph-ansible upstream purge playbooks), so it is never syntax-checked — the mock is dead configuration.

Newer ansible-core (in the current `ansible-lint` image) no longer lets bare `mock_modules` satisfy the syntax-check phase, so bare mocks are being retired across OSISM repos. Removing this unused one keeps the repo off the broken mechanism. Verified against the `ansible-lint` image: lint still passes clean without it.

Related:

- osism/issues#1412

🤖 Generated with [Claude Code](https://claude.com/claude-code)