### PR TITLE
ceph: retry image pull on transient errors

### DIFF
--- a/files/playbooks/quincy/ceph-pull-image.yml
+++ b/files/playbooks/quincy/ceph-pull-image.yml
@@ -8,3 +8,7 @@
       community.docker.docker_image:
         name: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_image_version }}"
         source: pull
+      register: result
+      until: result is success
+      retries: 3
+      delay: 30

--- a/files/playbooks/reef/ceph-pull-image.yml
+++ b/files/playbooks/reef/ceph-pull-image.yml
@@ -8,3 +8,7 @@
       community.docker.docker_image:
         name: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_image_version }}"
         source: pull
+      register: result
+      until: result is success
+      retries: 3
+      delay: 30

--- a/files/playbooks/squid/ceph-pull-image.yml
+++ b/files/playbooks/squid/ceph-pull-image.yml
@@ -8,3 +8,7 @@
       community.docker.docker_image:
         name: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_image_version }}"
         source: pull
+      register: result
+      until: result is success
+      retries: 3
+      delay: 30


### PR DESCRIPTION
## What

Add a retry to the `Pull container image` task in
`files/playbooks/{quincy,reef,squid}/ceph-pull-image.yml`. The three files were
byte-identical before and still are.

## Why

Follow-up to the same class of failure as:

- osism/ansible-collection-services#2150

The Ceph image comes from `ceph_docker_registry`, which defaults to `quay.io`
(`defaults/all/099-registries.yml` in the release defaults). That is a
third-party registry OSISM does not control and which returns transient 5xx
errors, so a single bad response failed the task and with it the whole pull
action.

Two things make this worse than the manager case: the playbook runs against
every host in the `ceph` group, so exposure scales with the number of storage
nodes, and there was no retry at all.

## Not the two-line diff — and why

The obvious change was to copy #2150 verbatim (`retries: 3` / `delay: 30`,
no `until`). That would have been a **silent no-op on quincy**.

The bare-`retries` form relies on ansible-core falling back to an implicit
condition on the task not having failed when `until` is unset. That fallback
was introduced in 2.16:

```python
# 2.16.19 — executor/task_executor.py
retries = 1                                    # default run + user retries
if self._task.retries is not None:
    retries += max(0, self._task.retries)
elif self._task.until:
    retries += 3
...
cond.when = self._task.until or [not result['failed']]
```

```python
# 2.15.13 — executor/task_executor.py
if self._task.until:                           # <-- whole block gated
    retries = self._task.retries
    ...
else:
    retries = 1                                # <-- bare "retries" is a no-op
...
cond.when = self._task.until
```

These images pin ansible-core per Ceph release in the release repo
(`latest/ceph-*.yml`):

| Release | `ansible_core_version` | bare `retries` effective? |
|---|---|---|
| quincy | 2.15.13 | **no** |
| reef | 2.16.19 | yes |
| squid | 2.16.19 | yes |

So quincy would have kept its single attempt while looking protected.

Registering the result and setting `until` explicitly works on every pinned
version and keeps the three playbooks identical:

```yaml
      community.docker.docker_image:
        name: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_image_version }}"
        source: pull
      register: result
      until: result is success
      retries: 3
      delay: 30
```

## Verification

Source reading is not proof, so this was measured with a probe playbook whose
task always fails, run against both pinned versions (on Python 3.11 —
ansible-core 2.15 cannot run on 3.14, `ast.Str` was removed in 3.12):

| | bare `retries: 3` | `register` + `until` |
|---|---|---|
| 2.15.13 (quincy) | **1 attempt, no retry**, `attempts` absent | 4 attempts, `attempts: 3` |
| 2.16.19 (reef/squid) | 4 attempts, `attempts: 3` | 4 attempts, `attempts: 3` |

Lint, over the staged files:

- `yamllint` (the repo's `.yamllint.yml`, via the `yamllint` Zuul job) — pass
- `ansible-lint` with the custom OSISM rules — `0 failure(s), 0 warning(s) in 3
  files processed`, last profile met `production`

The custom `osism-attribute-order` rule only constrains `name` / `become` /
`when`, so the placement of `until` / `retries` / `delay` is unconstrained.

## Risk

Low. On success the task behaves exactly as before. On failure it now takes up
to 90s longer per host before failing the action.

## Note on the sibling pull sites

`ansible-collection-services` runs under ansible-core 2.18, so the bare form in
#2150 and in the netbox and stepca tasks is effective today. It is only safe
while nothing runs those roles under &le;2.15, though, and it reads as portable
when it is not. Converting those four sites to the explicit form would be a
small separate cleanup — deliberately not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
